### PR TITLE
Use a custom scaling function in the map plot

### DIFF
--- a/app.R
+++ b/app.R
@@ -342,6 +342,10 @@ server <- function(input, output) {
     
   })
   
+  # custom scaling function to make sure that also zero values are shown
+  # and the different sizes are at most half of each other
+  my_scale <- function(x) scales::rescale(x, to = c(10, 20))
+  
   # The following plots (including the map) are generated with the package 
   # echarts4r (https://echarts4r.john-coene.com)
   # Map ------------------------------------------------------------------------
@@ -370,6 +374,7 @@ server <- function(input, output) {
       e_scatter(
         latitude,
         size = Fatalities,
+        scale = my_scale,
         coord_system = "geo",
         legend = FALSE
       ) %>%


### PR DESCRIPTION
All four categorizes can be shown on the same map, because rescaling will not make zero values now always visible:

![grafik](https://user-images.githubusercontent.com/5199995/91768426-e0339c80-ebdd-11ea-99fe-137bad3322e8.png)

This looks visually okay for me, also the sizes of the symbols now only show some indications on the number of fatalities, e.g. the largest point in the middle stands for 69 fatalities and is double the size of a point with 0 fatalities. One can also change the scaling interval if other values would be better for you.
